### PR TITLE
feat(Image): Add altair to midi image

### DIFF
--- a/images/executa-midi/requirements.txt
+++ b/images/executa-midi/requirements.txt
@@ -5,6 +5,7 @@
 absl-py
 adal
 aiohttp
+altair
 appdirs
 async-generator
 async-timeout
@@ -131,7 +132,6 @@ sqlparse
 statsmodels
 tabulate
 tensorflow
-testpath
 toml
 tqdm
 traitlets

--- a/images/packages/python/executa-midi.json
+++ b/images/packages/python/executa-midi.json
@@ -75,6 +75,7 @@
     "zope-interface"
   ],
   "include": [
+    "altair",
     "matplotlib",
     "networkx",
     "pandas",


### PR DESCRIPTION
This force includes the Python package [`altair`](https://altair-viz.github.io/index.html) to the `stencila/executa-midi` image (and drops the package `testpath` to keep the total number of Python packages at 150).

Altair is based on Vega/Vega-Lite, an alternative to Plotly for JS based plotting, and appears to be growing in usage amongst researchers. In our last analysis of downloads `altair` was in the [89th percentile of downloads](https://github.com/stencila/dockta/blob/master/images/packages/python/stats.tsv#L814) (`plotly` was at 74th percentile). 

`testpath` is a development / testing utility unlikely to be required for most executable documents.